### PR TITLE
Use `std::io::IsTerminal` instead of `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,17 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,15 +179,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -262,7 +242,6 @@ name = "netnyan"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "clap",
  "tokio",
  "tracing",
@@ -285,7 +264,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.75"
-atty = "0.2.14"
 clap = { version = "4.4.2", features = ["derive"] }
 tokio = { version = "1.32.0", features = ["full", "signal"] }
 tracing = "0.1.37"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use std::io::IsTerminal;
 use tokio::net::TcpStream;
 use tokio::sync::{broadcast, oneshot};
 
@@ -8,7 +9,7 @@ pub async fn run(destination: String, port: Option<u16>) -> anyhow::Result<()> {
     let (stream, sink) = stream.into_split();
     let (sender, proxy) = broadcast::channel(1);
 
-    if atty::is(atty::Stream::Stdin) {
+    if std::io::stdin().is_terminal() {
         use crate::net;
         tracing::debug!("from stdin");
         tokio::spawn(net::stdin(sender));


### PR DESCRIPTION
Fixes #14 